### PR TITLE
Fix: Correct Gradle settings and App Theme to resolve build errors

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.material) // Added Material Components
     
     // Compose
     implementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -3,15 +3,37 @@
 
     <style name="Theme.AuraFrameFX" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="colorPrimary">@color/neon_teal</item>
-        <item name="colorPrimaryVariant">@color/neon_blue</item>
         <item name="colorOnPrimary">@color/on_primary</item>
+        <item name="colorPrimaryContainer">@color/neon_blue</item>
+        <item name="colorOnPrimaryContainer">@color/on_primary</item>
+
         <item name="colorSecondary">@color/neon_purple</item>
-        <item name="colorSecondaryVariant">@color/neon_purple</item>
         <item name="colorOnSecondary">@color/on_surface</item>
+        <item name="colorSecondaryContainer">@color/neon_purple</item>
+        <item name="colorOnSecondaryContainer">@color/on_surface</item>
+
+        <item name="colorTertiary">@color/neon_blue</item>
+        <item name="colorOnTertiary">@color/on_surface</item>
+        <item name="colorTertiaryContainer">@color/neon_blue</item>
+        <item name="colorOnTertiaryContainer">@color/on_surface</item>
+
+        <item name="android:colorBackground">@color/dark_background</item>
+        <item name="colorSurface">@color/surface</item>
+        <item name="colorOnSurface">@color/on_surface</item>
+        <item name="colorSurfaceVariant">@color/surface_variant</item>
+        <item name="colorOnSurfaceVariant">@color/on_surface_variant</item>
+
+        <item name="colorError">@color/error</item>
+        <item name="colorOnError">@color/on_surface</item>
+        <item name="colorErrorContainer">@color/error</item>
+        <item name="colorOnErrorContainer">@color/on_surface</item>
+
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">false</item>
         <item name="android:windowLightNavigationBar">false</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <!-- You can also copy shapeAppearance and textAppearance items from Theme.AuraFrameFX.Material3 if needed -->
     </style>
 
     <style name="Theme.AuraFrameFX.SplashScreen" parent="Theme.SplashScreen">
@@ -33,4 +55,3 @@
         <item name="cardCornerRadius">12dp</item>
     </style>
 </resources>
-

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,7 +29,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         create("libs") {
-            (files("gradle/libs.versions.toml"))
+            from(files("gradle/libs.versions.toml"))
         }
     }
 }


### PR DESCRIPTION
This commit addresses critical build issues:

1.  **Gradle Settings (`settings.gradle.kts`):**
    *   Corrected the version catalog definition for `libs` by changing `(files("gradle/libs.versions.toml"))` to `from(files("gradle/libs.versions.toml"))`. This resolves potential "Unresolved reference 'libs'" errors and related type inference problems in Gradle build scripts.

2.  **App Theme (AAPT2 Errors):**
    *   Added the `com.google.android.material:material` dependency (via the existing `libs.androidx.material` alias) to `app/build.gradle.kts`. This provides the necessary base XML themes for Material 3.
    *   Updated the main application theme `Theme.AuraFrameFX` in `app/src/main/res/values/styles.xml` to use Material 3 compatible attributes and ensure it correctly parents from `Theme.Material3.DayNight.NoActionBar`. This should resolve AAPT2 errors related to missing theme resources and attributes.

These changes aim to create a more stable build foundation. Further work on `CascadeVisionController` and full serialization is pending reliable access to `VisionAnalysis.kt` and its model definitions.