### PR TITLE
Fix: Remove hardcoded org.gradle.java.home from gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
 # JVM and Java configuration
 org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-org.gradle.java.home=C:\\Program Files\\Java\\jdk-17.0.15+6
 org.gradle.caching=true
 # Build performance settings
 org.gradle.parallel=true


### PR DESCRIPTION
The `org.gradle.java.home` property was hardcoded to a Windows path, causing build failures in the GitHub Actions Ubuntu environment.

This change removes the hardcoded path, allowing Gradle to correctly use the `JAVA_HOME` environment variable set by the `actions/setup-java` action in the workflow. This ensures the build uses a valid Java home directory appropriate for the build environment.