### PR TITLE
Fix: Resolve "Unresolved reference: libs" in settings.gradle.kts

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,4 @@
+enableFeaturePreview("VERSION_CATALOGS")
 pluginManagement {
     repositories {
         gradlePluginPortal()


### PR DESCRIPTION
The `libs` version catalog was not accessible within the `pluginManagement` block in `settings.gradle.kts` because it was defined later in the script.

This change adds `enableFeaturePreview("VERSION_CATALOGS")` at the beginning of `settings.gradle.kts`. This makes the version catalog available earlier in the script's lifecycle, allowing `pluginManagement` to correctly resolve references to `libs` for plugin versions.