### PR TITLE
Fix: Correct order of blocks in settings.gradle.kts for version catalog

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,12 @@
 enableFeaturePreview("VERSION_CATALOGS")
+dependencyResolutionManagement {
+
+    versionCatalogs {
+        create("libs") {
+            from(files("gradle/libs.versions.toml"))
+        }
+    }
+}
 pluginManagement {
     repositories {
         gradlePluginPortal()
@@ -20,15 +28,6 @@ pluginManagement {
                     useVersion(libs.versions.kotlin.get())
                 }
             }
-        }
-    }
-}
-
-dependencyResolutionManagement {
-
-    versionCatalogs {
-        create("libs") {
-            from(files("gradle/libs.versions.toml"))
         }
     }
 }


### PR DESCRIPTION
Moved the `dependencyResolutionManagement` block (which defines the `libs` version catalog) to appear before the `pluginManagement` block in `settings.gradle.kts`.

This ensures that the `libs` version catalog is defined and available when the `pluginManagement` block's resolution strategy attempts to access `libs.versions.kotlin.get()`, resolving the "Unresolved reference: libs" error.

The `enableFeaturePreview("VERSION_CATALOGS")` line is kept at the beginning of the file.