### PR TITLE
Fix: Use gradle.properties for Kotlin plugin version in settings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -31,3 +31,4 @@ kotlin.daemon.jvm.options="-Xmx4096m"
 # Configuration cache
 org.gradle.unsafe.configuration-cache=true
 org.gradle.unsafe.configuration-cache-problems=warn
+kotlinPluginVersion=2.1.21

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,5 @@
 enableFeaturePreview("VERSION_CATALOGS")
+val kotlinPluginVersionForSettings = settings.providers.gradleProperty("kotlinPluginVersion").get()
 dependencyResolutionManagement {
 
     versionCatalogs {
@@ -25,7 +26,7 @@ pluginManagement {
                 "org.jetbrains.kotlin.android",
                 "org.jetbrains.kotlin.kapt",
                 "org.jetbrains.kotlin.plugin.serialization" -> {
-                    useVersion(libs.versions.kotlin.get())
+                    useVersion(kotlinPluginVersionForSettings)
                 }
             }
         }


### PR DESCRIPTION
To resolve the "Unresolved reference: libs" error when setting plugin versions in `settings.gradle.kts`, this change implements the following:

1. Defines `kotlinPluginVersion=2.1.21` in `gradle.properties`.
2. Modifies `settings.gradle.kts` to read this property using `settings.providers.gradleProperty("kotlinPluginVersion").get()`.
3. Updates the `pluginManagement` block to use this fetched version string for Kotlin plugins, instead of attempting to use `libs.versions.kotlin.get()`.

This decouples the Kotlin plugin version resolution in the settings script from the main version catalog's evaluation timing, providing a direct and reliable version string.