### PR TITLE
Fix: Use hardcoded Kotlin version in settings.gradle.kts

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 enableFeaturePreview("VERSION_CATALOGS")
-val kotlinPluginVersionForSettings: String = settings.providers.gradleProperty("kotlinPluginVersion").get()
+val kotlinPluginVersionForSettings = "2.1.21" // Hardcoded version
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {


### PR DESCRIPTION
I temporarily hardcoded the Kotlin version for plugin resolution in `settings.gradle.kts` to resolve an "Unresolved reference" error.

The line `val kotlinPluginVersionForSettings = "2.1.21"` is used to define the version directly, bypassing issues I encountered when trying to read this value from `gradle.properties` via `settings.providers.gradleProperty()` in this specific build environment.

This change ensures the `kotlinPluginVersionForSettings` variable is available when `pluginManagement` configures Kotlin plugin versions. I may do further work to address the version duplication with `gradle/libs.versions.toml` or `gradle.properties`.