### PR TITLE
Bump Android Gradle Plugin version to 8.5.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ targetSdk = "35"
 jvmTarget = "17"
 
 # Plugin versions
-agp = "8.3.0" # Updated AGP version for Kotlin 2.0 compatibility
+agp = "8.5.0" # Updated AGP version for stability and compatibility
 kotlin = "2.0.0" # Updated to Kotlin 2.0.0
 ksp = "2.0.0-1.0.21" # Updated KSP for Kotlin 2.0
 dokka = "2.0.0" # Updated Dokka for Kotlin 2.0


### PR DESCRIPTION
The Android Gradle Plugin (AGP) version has been updated from 8.3.0 to 8.5.0. This update is intended to improve stability and compatibility.