### PR TITLE
Gradle fixes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,10 +54,13 @@ android {
         }
     }
     
-    // Skip xposed flavor in CI environment to avoid LSPosed dependency issues
-    variantFilter {
-        if (System.getenv("CI") == "true" && flavors.any { it.name.contains("xposed", ignoreCase = true) }) {
-            ignore = true
+    // Skip xposed flavor in CI environment to avoid LSPosed dependency issues using the new API
+    androidComponents {
+        beforeVariants { variantBuilder ->
+            if (System.getenv("CI") == "true" && 
+                variantBuilder.flavorName?.contains("xposed", ignoreCase = true) == true) {
+                variantBuilder.enable = false
+            }
         }
     }
 
@@ -104,6 +107,10 @@ android {
         getByName("main") {
             java.srcDirs("build/generated/src/main/kotlin")
         }
+    }
+
+    sourceSets.all {
+        languageSettings.optIn("kotlinx.serialization.InternalSerializationApi")
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,13 +48,16 @@ android {
     productFlavors {
         create("xposed") {
             dimension = "xposed"
-            // Skip this flavor during CI builds to avoid LSPosed dependency issues
-            if (System.getenv("CI") == "true") {
-                setIgnore(true)
-            }
         }
         create("vanilla") {
             dimension = "xposed"
+        }
+    }
+    
+    // Skip xposed flavor in CI environment to avoid LSPosed dependency issues
+    variantFilter {
+        if (System.getenv("CI") == "true" && flavors.any { it.name.contains("xposed", ignoreCase = true) }) {
+            ignore = true
         }
     }
 

--- a/app/src/main/java/com/example/app/ui/debug/CascadeZOrderPlayground.kt
+++ b/app/src/main/java/com/example/app/ui/debug/CascadeZOrderPlayground.kt
@@ -12,6 +12,7 @@ import com.example.app.model.agent_states.VisionState
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 import javax.inject.Singleton
+import androidx.compose.ui.tooling.preview.Preview
 
 @Singleton
 class CascadeDebugViewModel @Inject constructor(
@@ -65,8 +66,9 @@ fun CascadeZOrderPlayground(
                     modifier = Modifier.padding(bottom = 8.dp)
                 )
 
+                val visionState by viewModel.visionState.collectAsState()
                 Text(
-                    text = "Current State: ${viewModel.visionState.value}",
+                    text = "Current State: $visionState",
                     modifier = Modifier.padding(bottom = 16.dp)
                 )
 
@@ -105,8 +107,9 @@ fun CascadeZOrderPlayground(
                     modifier = Modifier.padding(bottom = 8.dp)
                 )
 
+                val processingState by viewModel.processingState.collectAsState()
                 Text(
-                    text = "Current State: ${viewModel.processingState.value}",
+                    text = "Current State: $processingState",
                     modifier = Modifier.padding(bottom = 16.dp)
                 )
 
@@ -154,7 +157,8 @@ fun CascadeZOrderPlayground(
                             text = "Vision History",
                             style = MaterialTheme.typography.titleSmall
                         )
-                        viewModel.visionState.value.history?.forEach { entry ->
+                        val visionState by viewModel.visionState.collectAsState()
+                        visionState.history?.forEach { entry ->
                             Text(text = "- $entry")
                         }
                     }
@@ -163,7 +167,8 @@ fun CascadeZOrderPlayground(
                             text = "Processing History",
                             style = MaterialTheme.typography.titleSmall
                         )
-                        viewModel.processingState.value.history?.forEach { entry ->
+                        val processingState by viewModel.processingState.collectAsState()
+                        processingState.history?.forEach { entry ->
                             Text(text = "- $entry")
                         }
                     }


### PR DESCRIPTION
Go Go dependo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved CI build configuration to skip the "xposed" flavor more reliably.
  - Enabled opt-in for Kotlin serialization internal API across all source sets.

- **Refactor**
  - Updated state management in the debug playground screen for better reactivity and Compose compatibility.
  - Added support for Compose previews in the debug playground screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->