### PR TITLE
Revert "Gradle fixes"

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,19 +48,13 @@ android {
     productFlavors {
         create("xposed") {
             dimension = "xposed"
+            // Skip this flavor during CI builds to avoid LSPosed dependency issues
+            if (System.getenv("CI") == "true") {
+                setIgnore(true)
+            }
         }
         create("vanilla") {
             dimension = "xposed"
-        }
-    }
-    
-    // Skip xposed flavor in CI environment to avoid LSPosed dependency issues using the new API
-    androidComponents {
-        beforeVariants { variantBuilder ->
-            if (System.getenv("CI") == "true" && 
-                variantBuilder.flavorName?.contains("xposed", ignoreCase = true) == true) {
-                variantBuilder.enable = false
-            }
         }
     }
 
@@ -107,10 +101,6 @@ android {
         getByName("main") {
             java.srcDirs("build/generated/src/main/kotlin")
         }
-    }
-
-    sourceSets.all {
-        languageSettings.optIn("kotlinx.serialization.InternalSerializationApi")
     }
 }
 

--- a/app/src/main/java/com/example/app/ui/debug/CascadeZOrderPlayground.kt
+++ b/app/src/main/java/com/example/app/ui/debug/CascadeZOrderPlayground.kt
@@ -12,7 +12,6 @@ import com.example.app.model.agent_states.VisionState
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 import javax.inject.Singleton
-import androidx.compose.ui.tooling.preview.Preview
 
 @Singleton
 class CascadeDebugViewModel @Inject constructor(
@@ -66,9 +65,8 @@ fun CascadeZOrderPlayground(
                     modifier = Modifier.padding(bottom = 8.dp)
                 )
 
-                val visionState by viewModel.visionState.collectAsState()
                 Text(
-                    text = "Current State: $visionState",
+                    text = "Current State: ${viewModel.visionState.value}",
                     modifier = Modifier.padding(bottom = 16.dp)
                 )
 
@@ -107,9 +105,8 @@ fun CascadeZOrderPlayground(
                     modifier = Modifier.padding(bottom = 8.dp)
                 )
 
-                val processingState by viewModel.processingState.collectAsState()
                 Text(
-                    text = "Current State: $processingState",
+                    text = "Current State: ${viewModel.processingState.value}",
                     modifier = Modifier.padding(bottom = 16.dp)
                 )
 
@@ -157,8 +154,7 @@ fun CascadeZOrderPlayground(
                             text = "Vision History",
                             style = MaterialTheme.typography.titleSmall
                         )
-                        val visionState by viewModel.visionState.collectAsState()
-                        visionState.history?.forEach { entry ->
+                        viewModel.visionState.value.history?.forEach { entry ->
                             Text(text = "- $entry")
                         }
                     }
@@ -167,8 +163,7 @@ fun CascadeZOrderPlayground(
                             text = "Processing History",
                             style = MaterialTheme.typography.titleSmall
                         )
-                        val processingState by viewModel.processingState.collectAsState()
-                        processingState.history?.forEach { entry ->
+                        viewModel.processingState.value.history?.forEach { entry ->
                             Text(text = "- $entry")
                         }
                     }


### PR DESCRIPTION
Fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified state observation in the debug UI by directly accessing state values instead of collecting them as Compose states.
  - Streamlined the build configuration for CI by directly ignoring the "xposed" flavor when running in CI environments.
- **Chores**
  - Removed unnecessary import and obsolete language feature opt-in from the build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->