### PR TITLE
Fix: Correct syntax error in settings.gradle.kts

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,7 +18,7 @@ pluginManagement {
         id("io.netty:netty-handler") version "4.1.118"
       id("org.bouncycastle:bcprov-jdk18on") version "1.78"
         id("io.netty:netty-common") version "4.1.118"
-        id("org.apache.commons:commons-compress") "1.26.0"
+        id("org.apache.commons:commons-compress") version "1.26.0"
         id("com.google.guava:guava") version "32.0.0-android"
         id("io.netty:netty-codec-http") version "4.1.108.Final"
 


### PR DESCRIPTION
The `version` keyword was missing in the plugin declaration for `org.apache.commons:commons-compress`. This commit adds the missing keyword to resolve the build failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the plugin version specification to ensure proper Gradle build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->