### PR TITLE
I've addressed the Compose dependency resolution issue by removing in…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,11 +67,7 @@ subprojects {
             
             // Force consistent Compose versions
             force("androidx.compose.compiler:compiler:1.5.15")
-            force("androidx.compose.runtime:runtime:1.5.14")
-            force("androidx.compose.foundation:foundation:1.5.14")
             force("androidx.compose.material3:material3:1.1.2")
-            force("androidx.compose.ui:ui:1.5.14")
-            force("androidx.compose.ui:ui-tooling:1.5.14")
             force("androidx.compose.ui:ui-tooling-preview:1.8.2")
             
             // Retrofit to a specific version


### PR DESCRIPTION
…correct force statements.

Specifically, I removed the `force` declarations for `androidx.compose.runtime`, `androidx.compose.foundation`, `androidx.compose.ui`, and `androidx.compose.ui:ui-tooling` from your root `build.gradle.kts` file.

These `force` statements were overriding the versions defined in the `androidx.compose.bom` and were pointing to versions (e.g., 1.5.14) that were unavailable in the Google Maven repository for some artifacts.

This change allows the Compose BOM to correctly manage the versions of these core Compose libraries, which should resolve the "Could not find" errors you were encountering during dependency resolution.

I attempted to verify this with a full clean build, but encountered an unrelated, persistent SDK location issue in the test build environment which prevented me from completing the verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated dependency management to allow more flexibility in Compose library versions, potentially improving compatibility with other libraries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->