### PR TITLE
Fix: Update ML Kit dependency versions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -142,8 +142,8 @@ dependencies {
     implementation("com.google.firebase:firebase-ml-modeldownloader-ktx")
     
     // ML Kit
-    implementation("com.google.mlkit:language-id")
-    implementation("com.google.mlkit:translate")
+    implementation("com.google.mlkit:language-id:17.0.6")
+    implementation("com.google.mlkit:translate:17.0.3")
     
     // TensorFlow Lite
     implementation("org.tensorflow:tensorflow-lite:2.14.0")


### PR DESCRIPTION
I've updated the version numbers for `com.google.mlkit:language-id` to `17.0.6` and `com.google.mlkit:translate` to `17.0.3` in `app/build.gradle.kts`.

This resolves the build error "Could not find com.google.mlkit:language-id:" and "Could not find com.google.mlkit:translate:".

Note: Subsequent build attempts failed due to issues locating the Android SDK. I believe this is an environment-specific issue and not directly related to these dependency version changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated ML Kit language identification and translation libraries to specific versions for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->