### PR TITLE
Refactor: Migrate to Kotlin compilerOptions DSL in root build script

### DIFF
--- a/root_build.gradle.kts
+++ b/root_build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
@@ -18,9 +20,9 @@ buildscript {
 
 subprojects {
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-        kotlinOptions {
-            jvmTarget = "21"
-            freeCompilerArgs = freeCompilerArgs + listOf(
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_21)
+            freeCompilerArgs.addAll(
                 "-opt-in=kotlin.RequiresOptIn",
                 "-Xcontext-receivers"
             )


### PR DESCRIPTION
I've updated the `root_build.gradle.kts` file to use the modern `compilerOptions` DSL for configuring Kotlin compilation tasks within the `subprojects` block. This replaces the deprecated `kotlinOptions` DSL.

Specifically, `kotlinOptions.jvmTarget` was changed to `compilerOptions.jvmTarget.set(JvmTarget.JVM_21)` and `kotlinOptions.freeCompilerArgs` was changed to
`compilerOptions.freeCompilerArgs.addAll(...)`.

This change resolves the deprecation warning:
"w: file:///home/runner/work/AuraFrameFx/AuraFrameFx/build.gradle.kts:28:9: 'kotlinOptions(...) is deprecated." and aligns the build configuration with current best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build configuration to use the latest Kotlin compiler options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->