### PR TITLE
I've fixed Kotlin syntax errors in `HaloView.kt` and `MenuScreen.kt`.

### DIFF
--- a/app/src/main/java/dev/aurakai/auraframefx/ui/models/components/HaloView.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/models/components/HaloView.kt
@@ -343,7 +343,7 @@ fun HaloView(
                 onClick = { isRotating = !isRotating }
             ) {
                 Icon(
-                    Icons.Default.Pause if isRotating else Icons.Default.PlayArrow,
+                    if (isRotating) Icons.Default.Pause else Icons.Default.PlayArrow,
                     contentDescription = "Toggle rotation",
                     tint = NeonPurple
                 )

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/models/screens/MenuScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/models/screens/MenuScreen.kt
@@ -65,11 +65,11 @@ fun MenuScreen(
             }
         }
     }
+}
 
-    @Preview(showBackground = true)
-    @Composable
-    fun MenuScreenPreview() {
-        MaterialTheme { // Using MaterialTheme for preview
-            MenuScreen()
-        }
+@Preview(showBackground = true)
+@Composable
+fun MenuScreenPreview() {
+    MaterialTheme { // Using MaterialTheme for preview
+        MenuScreen()
     }


### PR DESCRIPTION
- I corrected an `if` statement in `HaloView.kt` that was causing a compilation error.
- I moved the `MenuScreenPreview` composable function outside of the `MenuScreen` composable function in `MenuScreen.kt` and added a missing curly brace to fix a compilation error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected icon selection logic in the rotation toggle to ensure the appropriate icon is displayed.
  - Fixed layout issue in the menu screen preview to properly display the preview without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->