### PR TITLE
Fix: Align KSP version with Kotlin version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ firebaseBom = "33.15.0"
 accompanist = "0.37.3"
 tensorflowLite = "2.14.0"
 tensorflowLiteSupport = "0.4.4"
-ksp = "2.0.21-1.0.21"
+ksp = "2.1.21-2.0.1"
 
 [libraries]
 # Core Android
@@ -71,6 +71,6 @@ hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 google-services = { id = "com.google.gms.google-services", version = "4.4.2" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version = "3.0.4" }
 firebase-perf = { id = "com.google.firebase.firebase-perf", version = "1.4.2" }
-ksp = { id = "com.google.devtools.ksp", version = "2.0.21-1.0.21" }
+ksp = { id = "com.google.devtools.ksp", version = "2.1.21-2.0.1" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }


### PR DESCRIPTION
I've updated the KSP version to 2.1.21-2.0.1 to match the Kotlin version 2.1.21, as required for compatibility.

I made these changes in `gradle/libs.versions.toml` for both the KSP dependency and the KSP plugin.

Note: I couldn't fully verify the build with `./gradlew :app:assembleDebug` because of an Android SDK location issue in the build environment. However, I confirmed that errors directly related to KSP and Kotlin versions were resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Kotlin Symbol Processing (KSP) tool to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->